### PR TITLE
Fix problems with older PHP versions

### DIFF
--- a/README
+++ b/README
@@ -21,6 +21,8 @@ running the scripts on a large number of files are written in Bash and will
 therefore not run on Windows without additional software, like Cygwin.
 This framework requires the installation of PHP-CLI (Command Line Interface),
 available from http://php.net/.
+This framework has been developed and tested using PHP 5.4 and up, but may work
+with earlier versions.
 
 
 

--- a/README
+++ b/README
@@ -129,7 +129,7 @@ reference, using the following bash code:
 cut -f 1 transcriptome_alignment_unsupported_transcripts.txt | grep -v '^#' \
     > transcriptome_alignment_unsupported_transcripts_list.txt
 tr '\n' '+' < mouse.rna.fna | sed 's/+>/\n>/g' \
-    | grep -vf transcriptome_alignment_unsupported_transcripts_list.txt \
+    | grep -vFf transcriptome_alignment_unsupported_transcripts_list.txt \
     | tr '+' '\n' > mouse.rna.fna.no_unsupported.fa
 
 The resulting file (mouse.rna.fna.no_unsupported.fa) is then used to create a

--- a/get_read_length_per_gene.php
+++ b/get_read_length_per_gene.php
@@ -14,11 +14,17 @@
  * It also creates a summary file, with all read lengths summed up.
  *
  * Created     : 2015-01-13
- * Modified    : 2015-01-15
- * Version     : 0.1
+ * Modified    : 2015-09-12
+ * Version     : 0.2
  *
- * Copyright   : 2015 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2015-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ * Changelog   : 0.2     2016-09-12
+ *               Added link to inc-lib-json.php to be compatible with PHP
+ *               versions < 5.2.0.
+ *               0.1     2015-01-15
+ *               First version.
  *
  *
  * This work is licensed under the Creative Commons
@@ -31,7 +37,7 @@
 
 $_SETT =
     array(
-        'version' => '0.1',
+        'version' => '0.2',
         'output_file_format' => '{{GENE}}_{{TRANSCRIPT}}_read_length_distribution.txt',
         'terminal_width' => 100,
     );
@@ -41,6 +47,10 @@ echo 'GetReadLengthPerTranscript v.' . $_SETT['version'] . "\n";
 
 $aFiles = $_SERVER['argv'];
 $sScriptName = array_shift($aFiles);
+$sCWD = dirname($sScriptName);
+if (!function_exists('json_encode') && is_readable($sCWD . '/inc-lib-json.php')) {
+    require $sCWD . '/inc-lib-json.php'; // For PHP <= 5.2.0.
+}
 if (count($aFiles) < 4) {
     die('Usage: ' . $sScriptName . ' FILE_WITH_GENES_TO_ANALYSE GENE_LIST_FILE TRANSCRIPT_POSITION_FILE SAM_FILE1 [SAM_FILE2 [SAM_FILE3 [...]]]' . "\n\n");
 }

--- a/inc-lib-json.php
+++ b/inc-lib-json.php
@@ -1,0 +1,74 @@
+<?php
+/*******************************************************************************
+ *
+ * This script provides the JSON related functions for PHP versions that do not
+ * contain these, i.e. PHP < 5.2.0.
+ *
+ *
+ * Code taken with permission from:
+ * https://gajendrakrjain.wordpress.com/2014/10/07/alternative-for-json_decode-and-json_encode/
+ *
+ * This work is licensed under the Creative Commons
+ * Attribution-NonCommercial-ShareAlike 4.0 International License. To view a
+ * copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/
+ * or send a letter to:
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ *************/
+
+if (!function_exists('json_encode')) {
+    function json_encode($a = false)
+    {
+        // Some basic debugging to ensure we have something returned.
+        if (is_null($a)) return 'null';
+        if ($a === false) return 'false';
+        if ($a === true) return 'true';
+        if (is_scalar($a)) {
+            if (is_float($a)) {
+                // Always use '.' for floats.
+                return floatval(str_replace(',', '.', strval($a)));
+            }
+            if (is_string($a)) {
+                static $jsonReplaces = array(array('\\', '/', "\n", "\t", "\r", "\b", "\f", '"'), array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"'));
+                return '"' . str_replace($jsonReplaces[0], $jsonReplaces[1], $a) . '"';
+            } else
+                return $a;
+        }
+        $isList = true;
+        for ($i = 0, reset($a); true; $i++) {
+            if (key($a) !== $i) {
+                $isList = false;
+                break;
+            }
+        }
+        $result = array();
+        if ($isList) {
+            foreach ($a as $v) $result[] = json_encode($v);
+            return '[' . join(',', $result) . ']';
+        } else {
+            foreach ($a as $k => $v) $result[] = json_encode($k) . ':' . json_encode($v);
+            return '{' . join(',', $result) . '}';
+        }
+    }
+}
+
+if (!function_exists('json_decode')) {
+    function json_decode($json)
+    {
+        $comment = false;
+        $out = '$x=';
+        for ($i = 0; $i < strlen($json); $i++) {
+            if (!$comment) {
+                if (($json[$i] == '{') || ($json[$i] == '[')) $out .= ' array('; else if (($json[$i] == '}') || ($json[$i] == ']')) $out .= ')'; else if ($json[$i] == ':') $out .= '=>';
+                else
+                    $out .= $json[$i];
+            } else
+                $out .= $json[$i];
+            if ($json[$i] == '"' && $json[($i - 1)] != "\\")
+                $comment = !$comment;
+        }
+        eval($out . ';');
+        return $x;
+    }
+}
+?>

--- a/mm10_transcript_positions_create.php
+++ b/mm10_transcript_positions_create.php
@@ -8,11 +8,20 @@
  * as the first argument.
  *
  * Created     : 2013-08-22
- * Modified    : 2013-09-05
- * Version     : 0.1
+ * Modified    : 2016-09-12
+ * Version     : 0.3
  *
- * Copyright   : 2013-2015 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2013-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ * Changelog   : 0.3     2016-09-12
+ *               Added link to inc-lib-json.php to be compatible with PHP
+ *               versions < 5.2.0.
+ *               0.2     2016-09-09
+ *               Updated preg_match_all() call to be compatible with PHP
+ *               versions < 5.4.0.
+ *               0.1     2013-09-05
+ *               First version.
  *
  *
  * This work is licensed under the Creative Commons
@@ -25,7 +34,7 @@
 
 $_SETT =
     array(
-        'version' => '0.1',
+        'version' => '0.3',
         'output' => 'mm10_transcript_positions.txt',
         'unsupported_transcripts_output' => 'transcriptome_alignment_unsupported_transcripts.txt',
         'terminal_width' => 100,
@@ -36,6 +45,10 @@ echo 'CreateTranscriptPositions v.' . $_SETT['version'] . "\n" .
 
 $aFiles = $_SERVER['argv'];
 $sScriptName = array_shift($aFiles);
+$sCWD = dirname($sScriptName);
+if (!function_exists('json_encode') && is_readable($sCWD . '/inc-lib-json.php')) {
+    require $sCWD . '/inc-lib-json.php'; // For PHP <= 5.2.0.
+}
 if (count($aFiles) != 1) {
     die('Usage: ' . $sScriptName . ' SAM_FILE' . "\n\n");
 }
@@ -131,7 +144,7 @@ while ($sLine = fgets($fIn)) {
          */
     }
 
-    if ($sTranscript && preg_match('/^chr([XYM]|\d{1,2})$/', $sChromosome) && $nPosition && preg_match_all('/^(\d+[MIDNSHP])+$/', $sCIGAR)) {
+    if ($sTranscript && preg_match('/^chr([XYM]|\d{1,2})$/', $sChromosome) && $nPosition && preg_match_all('/^(\d+[MIDNSHP])+$/', $sCIGAR, $aTMP)) {
         // All seem OK. Store basic info first.
         $sChromosome = substr($sChromosome, 3);
         $aData[$sTranscript] = array($sChromosome, $sStrand);

--- a/packed_sam2wiggle.php
+++ b/packed_sam2wiggle.php
@@ -9,11 +9,31 @@
  * unfiltered, and R filtered.
  *
  * Created     : 2013-08-21
- * Modified    : 2013-09-19
- * Version     : 0.4
+ * Modified    : 2016-09-12
+ * Version     : 0.5
  *
- * Copyright   : 2013-2015 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2013-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ * Changelog   : 0.5     2016-09-12
+ *               Added link to inc-lib-json.php to be compatible with PHP
+ *               versions < 5.2.0.
+ *               0.4     2013-09-19
+ *               Now produces both unfiltered and filtered wiggle files, per
+ *               strand. The filtered wiggle file contains no coverage on NR or
+ *               XR transcripts, since these don't have an open reading frame
+ *               anyway.
+ *               0.3     2013-09-19
+ *               Fixed bug; The track line was repeated for every chromosome,
+ *               instead of just one per file.
+ *               Also, if the transcript position file was not passed as an
+ *               argument, the script just took the first packed sam file,
+ *               ignored the fact that no transcripts were found, and continued
+ *               creating empty wiggle files. Now, the script halts when no
+ *               valid transcript positions file is passed.
+ *               0.2     2013-09-18
+ *               0.1     2013-08-21
+ *               First version.
  *
  *
  * This work is licensed under the Creative Commons
@@ -26,7 +46,7 @@
 
 $_SETT =
     array(
-        'version' => '0.4',
+        'version' => '0.5',
         'suffix' => '.wig5',
     );
 
@@ -35,6 +55,10 @@ echo 'PackedSam2Wiggle v.' . $_SETT['version'] . "\n" .
 
 $aFiles = $_SERVER['argv'];
 $sScriptName = array_shift($aFiles);
+$sCWD = dirname($sScriptName);
+if (!function_exists('json_encode') && is_readable($sCWD . '/inc-lib-json.php')) {
+    require $sCWD . '/inc-lib-json.php'; // For PHP <= 5.2.0.
+}
 if (count($aFiles) < 2) {
     die('Usage: ' . $sScriptName . ' TRANSCRIPT_POSITION_FILE PACKED_SAM_FILE1 [PACKED_SAM_FILE2 [...]]' . "\n\n");
 }


### PR DESCRIPTION
Fixes some problems existing in older PHP versions (PHP < 5.4.0). We won't officially support PHP versions below 5.4.0, but as long as it's a simple change to help a users, we can make those changes.
- mm10_transcript_positions_create.php:
  - Updated preg_match_all() call to be compatible with PHP versions < 5.4.0.
- get_read_length_per_gene.php, mm10_transcript_positions_create.php, packed_sam2wiggle.php:
  - Added link to inc-lib-json.php to be compatible with PHP versions < 5.2.0.
  - The code in inc-lib-json.php is taken, with permission, from gajendrakrjain.wordpress.com.
- Updated readme to mention minimal required PHP version (5.4), and made a small speed improvement to a bash command there.
